### PR TITLE
AWS s3 us-east-1 Support

### DIFF
--- a/bootstrapper/lib/archive_utils.py
+++ b/bootstrapper/lib/archive_utils.py
@@ -267,13 +267,19 @@ def create_s3_bucket(files, bucket_prefix, location, access_key, secret_key):
 
     try:
         print('creating bucket {}'.format(bucket_name))
-        response = client.create_bucket(
-            ACL='private',
-            Bucket=bucket_name,
-            CreateBucketConfiguration={
-                'LocationConstraint': location
-            },
-        )
+        if location == 'us-east-1':
+            response = client.create_bucket(
+                ACL='private',
+                Bucket=bucket_name
+            )
+        else:
+            response = client.create_bucket(
+                ACL='private',
+                Bucket=bucket_name,
+                CreateBucketConfiguration={
+                    'LocationConstraint': location
+                },
+            )
         print(response)
 
         for d in ['config', 'content', 'software', 'license']:


### PR DESCRIPTION
Added a conditional in archived_utils.py to the `create_s3_bucket` function to support bucket creation in the US-East-1 region due to boto3 nuance. 

[AWS Example](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-example-creating-buckets.html)
[Medium Article](https://medium.com/@DQNEO/amazon-s3s-put-bucket-api-cannot-accept-us-east-1-region-6092df86991b)
[AWS API Refrence](https://docs.aws.amazon.com/en_pv/AmazonS3/latest/API/API_CreateBucket.html)